### PR TITLE
Add scheduled trigger for WebAPI CI workflow

### DIFF
--- a/.github/workflows/webapi-ci.yml
+++ b/.github/workflows/webapi-ci.yml
@@ -3,10 +3,12 @@ name: WebAPI Continuous Integration
 on:
   push:
     branches:
-      - development
+      - dev
     paths:
       - 'src/webapi/**'
-  workflow_dispatch:
+  workflow_dispatch: # Manually trigger the workflow
+  schedule:
+    - cron: '0 0 * * *' # Run every day at midnight
 
 env:
   DOCKER_IMAGE: prasadhonrao/sportiverse-webapi


### PR DESCRIPTION
This pull request includes updates to the WebAPI Continuous Integration workflow configuration. The changes aim to improve the flexibility and scheduling of the CI process.

Key changes in `.github/workflows/webapi-ci.yml`:

* Updated the branch name for triggering the workflow from `development` to `dev` to align with the new branch naming convention.
* Added a comment to clarify the purpose of the `workflow_dispatch` trigger, indicating it is for manually triggering the workflow.
* Introduced a new schedule trigger to run the workflow every day at midnight using a cron expression.