### PR TITLE
Update version endpoint to return version 1.2

### DIFF
--- a/src/webapi/routes/homeRoutes.js
+++ b/src/webapi/routes/homeRoutes.js
@@ -7,7 +7,7 @@ router.get('/', (req, res) => {
 });
 
 router.get('/version', (req, res) => {
-  res.status(200).send('1.1');
+  res.status(200).send('1.2');
 });
 
 router.get('/status', (req, res) => {


### PR DESCRIPTION
Change the version returned by the version endpoint to 1.2 for testing deployment purposes.