### PR TITLE
Add OS detection and Docker startup script to setup.sh

### DIFF
--- a/src/webapi/setup.sh
+++ b/src/webapi/setup.sh
@@ -1,6 +1,43 @@
+#!/bin/bash
+
+# Detect OS
+OS=$(uname -s)
+
+# Start Docker Desktop based on OS
+case $OS in
+    Darwin)  # macOS
+        echo "Starting Docker on macOS..."
+        open -a Docker
+        ;;
+    Linux)   # Linux
+        echo "Starting Docker on Linux..."
+        # Ensure Docker service is started
+        sudo systemctl start docker
+        ;;
+    CYGWIN*|MINGW*|MSYS*)  # Windows (Git Bash, WSL)
+        echo "Starting Docker on Windows..."
+        # For Git Bash or WSL, use PowerShell command to start Docker Desktop
+        powershell.exe -Command "Start-Process 'C:\Program Files\Docker\Docker\Docker Desktop.exe'"
+        ;;
+    *) 
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Wait for Docker to start
+echo "Waiting for Docker to initialize..."
+while ! docker info > /dev/null 2>&1; do
+    sleep 2
+done
+
+echo "Docker is now running!"
+
+# Run Docker container
 docker run -d --rm -p 27017:27017 --name sportiverse-db \
 -e MONGO_INITDB_ROOT_USERNAME=admin \
 -e MONGO_INITDB_ROOT_PASSWORD=password \
 mongo
 
+# Run data import script
 npm run data:import


### PR DESCRIPTION
This pull request includes a significant update to the `src/webapi/setup.sh` script to enhance the Docker startup process based on the operating system. The most important changes include detecting the OS, starting Docker accordingly, and ensuring Docker is fully initialized before running the container and data import script.

Improvements to Docker startup process:

* [`src/webapi/setup.sh`](diffhunk://#diff-ba1317898ba67f73b75c5a282e2a80124eb8788bc978ddfba2635a4207368c9aR1-R42): Added OS detection logic to handle macOS, Linux, and Windows environments. The script now starts Docker Desktop based on the detected OS and waits for Docker to be fully initialized before proceeding.